### PR TITLE
gui_bag widget changes.

### DIFF
--- a/gui.c
+++ b/gui.c
@@ -344,26 +344,6 @@ void New_Down(widget_t *w, const int x, const int y, const int b)
   }
 }
 
-void Mix_Down(widget_t *w, const int x, const int y, const int b)
-{
-  button_gui_t *btn = (button_gui_t*)(w->wd);
-
-  if( Statec->player.mana < 0 ) {
-    return;
-  }
-
-  if( (x > ScaleX(w,w->x)) && (x < ScaleX(w,w->x+w->w)) && 
-      (y > ScaleY(w,w->y)) && (y < ScaleY(w,w->y+w->h))     ) {
-    // Don't even let the button be selected if not enough mana or no gem in hand.
-    if( (Statec->player.mana >= GEM_MIX_MANA_COST) && (GuiState.mouse_item_ndx != -1) ) {
-      // The bag can read the button's sel state, just flip it.
-      btn->sel ^= 1;
-    } else {
-      btn->sel = 0;
-    }
-  }
-}
-
 void Next_Down(widget_t *w, const int x, const int y, const int b)
 {
   //button_gui_t *btn = (button_gui_t*)(w->wd);
@@ -491,10 +471,8 @@ static void LayoutWidgets(glwindow_t *glw)
 {
   static button_gui_t    bquit  = {"Quit",      0, 0, NULL};
   static button_gui_t    bnew   = {"New Gem",   0, 0, NULL};
-  static button_gui_t    bmix   = {"Mix Gems",  0, 0, NULL};
   static button_gui_t    bnext  = {"Next Wave", 0, 0, NULL};
   static gameframe_gui_t gf;
-  static bag_gui_t       bag;
   static stats_gui_t     stats;
 
   // Main game frame
@@ -513,12 +491,10 @@ static void LayoutWidgets(glwindow_t *glw)
   // Buttons
   AddWidget(glw, 768, 8,    128-8,  24, Button_Draw,    NULL, Quit_Down,    NULL, NULL, NULL,  &bquit);
   AddWidget(glw, 768, 8+32, 128-8,  24, Button_Draw,    NULL, New_Down,     NULL, NULL, NULL,  &bnew);
-  AddWidget(glw, 768, 8+64, 128-8,  24, Button_Draw,    NULL, Mix_Down,     NULL, NULL, NULL,  &bmix);
-  AddWidget(glw, 768, 8+96, 128-8,  24, Button_Draw,    NULL, Next_Down,    NULL, NULL, NULL,  &bnext);
+  AddWidget(glw, 768, 8+64, 128-8,  24, Button_Draw,    NULL, Next_Down,    NULL, NULL, NULL,  &bnext);
 
   // Bag / Intentory
-  bag.mix_btn_link = &(bmix.sel);
-  AddWidget(glw, 768, (768-16)/2, 128-8, (768-16)/2+8, Bag_Draw, Bag_KeyPress, Bag_Down, NULL, Bag_MouseMove, NULL, &bag);
+  AddWidget(glw, 768, (768-16)/2, 128-8, (768-16)/2+8, Bag_Draw, Bag_KeyPress, Bag_Down, NULL, Bag_MouseMove, NULL, NULL);
 
   // Loss Message
   AddWidget(glw, 64, 64, glw->pwidth-128, glw->pheight-128, Loss_Draw, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/gui.h
+++ b/gui.h
@@ -79,6 +79,11 @@ typedef struct str_guistate_t {
 #define F11       95
 #define F12       96
 
+// Defines a min distance the cursor needs to be away from an object
+// to select it
+#define MIN_SELECT_DIST 10.0
+#define ISCLOSE(d) ((d) <= MIN_SELECT_DIST ? 1:0)
+
 // Holds what is needed to manage an opengl enabled window
 typedef struct {
   Display             *dpy;

--- a/gui.h
+++ b/gui.h
@@ -79,10 +79,12 @@ typedef struct str_guistate_t {
 #define F11       95
 #define F12       96
 
-// Defines a min distance the cursor needs to be away from an object
+// Defines a min/max distance the cursor needs to be away from an object
 // to select it
 #define MIN_SELECT_DIST 10.0
+#define MAX_SELECT_DIST 100.0
 #define ISCLOSE(d) ((d) <= MIN_SELECT_DIST ? 1:0)
+#define ISFAR(d) ((d) <= MAX_SELECT_DIST ? 1:0)
 
 // Holds what is needed to manage an opengl enabled window
 typedef struct {

--- a/gui_bag.h
+++ b/gui_bag.h
@@ -6,10 +6,6 @@
 
 #include "types.h"
 
-typedef struct {
-  u32b_t *mix_btn_link;  // Pointer to mix button's sel flag, so we know that button state.
-} bag_gui_t;
-
 ////////////////////////////////////////////////////////////
 // For files other than gui_bag.c
 #ifndef GUI_BAG_C

--- a/gui_gameframe.c
+++ b/gui_gameframe.c
@@ -415,7 +415,7 @@ static void DrawTowers(widget_t *w)
   for(i=0; i<Statec->player.ntowers; i++) {
     d = sqrt((Statec->player.towers[i].scr_pos.s.x-x)*(Statec->player.towers[i].scr_pos.s.x-x) +
 	     ((ScaleY(w,w->h)-Statec->player.towers[i].scr_pos.s.y)-y)*((ScaleY(w,w->h)-Statec->player.towers[i].scr_pos.s.y)-y));
-    if( d < nd ) {
+    if( d < nd && ISFAR(d) ) {
       nd = d;
       ni = i;
     }


### PR DESCRIPTION
1. Removed mix button from gui.
2. Added new MIN_SELECT_DIST and ISCLOSE() macro to gui.h. These are used to check if the cursor is within a predefined constant min dist from an object.
3. Modified the gui_bag widget to select gem only if the cursor is within the defined min distance via ISCLOSE() macro.
4. If a gem is selected, and clicked onto another gem, a mix event is generated. Otherwise the gem is dropped back into the bag.
5. Removed the bag_gui_t type. This isn't needed for the time being.
